### PR TITLE
get_run_path: create path if we're making one up

### DIFF
--- a/src/lxccmd/lxccmd/config.py
+++ b/src/lxccmd/lxccmd/config.py
@@ -21,6 +21,7 @@
 
 # Import everything we need
 import os
+import errno
 
 try:
     from configparser import ConfigParser
@@ -145,4 +146,11 @@ def get_run_path():
     if "XDG_RUNTIME_DIR" in os.environ:
         return os.path.join(os.environ["XDG_RUNTIME_DIR"], "lxc")
 
-    return os.path.join("/tmp", "lxc-%s" % os.geteuid())
+    path = os.path.join("/tmp", "lxc-%s" % os.geteuid())
+    try:
+        os.mkdir(path, 0o755)
+    except (OSError, e):
+        if e.errno != errno.EEXIST:
+            raise e
+        pass
+    return path


### PR DESCRIPTION
Otherwise we get:

Traceback (most recent call last):
  File "./lxc", line 91, in <module>
    args.func(args)
  File "/home/ubuntu/lxc/src/lxccmd/lxccmd/commands/server/**init**.py", line 216, in cli_start
    with open(os.path.join(get_run_path(), "server.pid"), "w+") as fd:
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/lxc-1000/server.pid'

Signed-off-by: Serge Hallyn serge.hallyn@ubuntu.com
